### PR TITLE
[QOL-5136] don't inject link tokens twice

### DIFF
--- a/ckanext/qgov/common/anti_csrf.py
+++ b/ckanext/qgov/common/anti_csrf.py
@@ -70,6 +70,8 @@ def apply_token(html):
         return form_match.group(1) + TOKEN_PATTERN.format(token=token) + form_match.group(2)
 
     def insert_link_token(link_match):
+        if TOKEN_FIELD_NAME + '=' in link_match.group(1):
+            return link_match.group(0)
         if '?' in link_match.group(2):
             separator = '&'
         else:


### PR DESCRIPTION
This is breaking dataset and resource deletion in Staging, needs to be fixed before we go to production.