### PR TITLE
[QOL-5426] override 'user_update' action to unlock the account

### DIFF
--- a/ckanext/qgov/common/intercepts.py
+++ b/ckanext/qgov/common/intercepts.py
@@ -17,7 +17,6 @@ import json
 
 LOG = getLogger(__name__)
 
-PERFORM_RESET = UserController.perform_reset
 USER_UPDATE = ckan.logic.action.update.user_update
 LOGGED_IN = UserController.logged_in
 PACKAGE_EDIT = PackageController._save_edit
@@ -38,7 +37,6 @@ EMAIL_REGEX = re.compile(r"[^@]+@[^@]+\.[^@]+")
 ALLOWED_EXTENSIONS = re.compile(r'.*((\.csv)|(\.xls)|(\.txt)|(\.kmz)|(\.xlsx)|(\.pdf)|(\.shp)|(\.tab)|(\.jp2)|(\.esri)|(\.gdb)|(\.jpg)|(\.tif)|(\.tiff)|(\.jpeg)|(\.xml)|(\.kml)|(\.doc)|(\.docx)|(\.rtf)|(\.json)|(\.accdb)|(\.geojson)|(\.geotiff)|(\.topojson)|(\.gpx)|(\.html)|(\.mtl)|(\.obj)|(\.ppt)|(\.pptx)|(\.wfs)|(\.wmts)|(\.zip))$', re.I)
 
 def set_intercepts():
-    UserController.perform_reset = perform_reset
     UserController.logged_in = logged_in
     PackageController._save_edit = save_edit
     PackageController.resource_edit = validate_resource_edit
@@ -103,16 +101,6 @@ def unlock_account(id):
         Session.commit()
     else:
         LOG.debug("Account {} not found".format(id))
-
-def perform_reset(self, id):
-    '''
-    Extending Reset to include login_attempts
-    Success loading original perform_reset indicates legitimate user
-    Set login_attempts to 0
-    '''
-    to_render = PERFORM_RESET(self, id)
-    unlock_account(id)
-    return to_render
 
 def user_update(context, data_dict):
     '''

--- a/ckanext/qgov/common/plugin.py
+++ b/ckanext/qgov/common/plugin.py
@@ -461,7 +461,6 @@ class QGOVPlugin(SingletonPlugin):
              m.connect('article', '/article/{path:[-_a-zA-Z0-9/]+}', action='static_content')
              return map
 
-
     def get_helpers(self):
         """ A dictionary of extra helpers that will be available
         to provide QGOV-specific helpers to the templates.
@@ -487,7 +486,8 @@ class QGOVPlugin(SingletonPlugin):
         """Extend actions API
         """
         return {
-            'submit_feedback' : submit_feedback
+            'submit_feedback' : submit_feedback,
+            'user_update': intercepts.user_update
         }
 
     def get_auth_functions(self):


### PR DESCRIPTION
This uses a different code path in CKAN 2.8 to CKAN 2.7, so our old patch no longer works.