### PR TITLE
Inject URL validator into scheming extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Queensland Government has developed this plugin to be used with data.qld.gov.au 
 * Static Routing on all index.html found in static-content directory
 * CSRF Protection
 * File upload known type verification
+* Resource URL filtering (domain whitelist/blacklist)
 * Statistics helpers
 * Custom feedback route
 * Password Strength validator

--- a/ckanext/qgov/common/plugin.py
+++ b/ckanext/qgov/common/plugin.py
@@ -470,6 +470,12 @@ class QGOVPlugin(SingletonPlugin):
             ckan_config['licenses_group_url'] = 'file://' \
                 + possible_licences_path
 
+        if 'scheming.presets' in ckan_config:
+            # inject our presets before the others so we can override them
+            ckan_config['scheming.presets'] = \
+                'ckanext.qgov.common:resources/scheming_presets.json ' \
+                + ckan_config['scheming.presets']
+
         # Theme Inclusions of public and templates
         possible_public_path = os.path.join(here, 'theme/public')
         if os.path.isdir(possible_public_path):

--- a/ckanext/qgov/common/resources/scheming_presets.json
+++ b/ckanext/qgov/common/resources/scheming_presets.json
@@ -1,0 +1,18 @@
+{
+  "scheming_presets_version": 1,
+  "about": "Presets related to data validation",
+  "about_url": "",
+  "presets": [
+    {
+      "preset_name": "data_qld_resource_url_upload",
+      "values": {
+        "validators": "scheming_required unicode remove_whitespace valid_resource_url",
+        "form_snippet": "upload.html",
+        "form_placeholder": "http://example.com/my-data.csv",
+        "upload_field": "upload",
+        "upload_clear": "clear_upload",
+        "upload_label": "File"
+      }
+    }
+  ]
+}

--- a/ckanext/qgov/common/resources/scheming_presets.json
+++ b/ckanext/qgov/common/resources/scheming_presets.json
@@ -4,6 +4,17 @@
   "about_url": "",
   "presets": [
     {
+      "preset_name": "resource_url_upload",
+      "values": {
+        "validators": "ignore_missing unicode remove_whitespace valid_resource_url",
+        "form_snippet": "upload.html",
+        "form_placeholder": "http://example.com/my-data.csv",
+        "upload_field": "upload",
+        "upload_clear": "clear_upload",
+        "upload_label": "File"
+      }
+    },
+    {
       "preset_name": "data_qld_resource_url_upload",
       "values": {
         "validators": "scheming_required unicode remove_whitespace valid_resource_url",


### PR DESCRIPTION
Override the scheming config, if any, to include the resource URL validator in the schema presets.