### PR TITLE
Clean up domain matching

### DIFF
--- a/ckanext/qgov/common/plugin.py
+++ b/ckanext/qgov/common/plugin.py
@@ -411,7 +411,7 @@ def _domain_match(hostname, pattern, address_resolution):
             return True, address_resolution
 
         address_resolution = _resolve_address(hostname, address_resolution)
-        if address_resolution == ():
+        if not address_resolution:
             # couldn't resolve hostname, nothing further to do
             return False, address_resolution
 
@@ -427,7 +427,7 @@ def _domain_match(hostname, pattern, address_resolution):
             return True, address_resolution
 
         address_resolution = _resolve_address(hostname, address_resolution)
-        if address_resolution == ():
+        if not address_resolution:
             # couldn't resolve hostname, nothing further to do
             return False, address_resolution
 
@@ -442,7 +442,7 @@ def _domain_match(hostname, pattern, address_resolution):
             return True, address_resolution
 
         address_resolution = _resolve_address(hostname, address_resolution)
-        if address_resolution == ():
+        if not address_resolution:
             # couldn't resolve hostname, nothing further to do
             return False, address_resolution
 
@@ -458,15 +458,27 @@ def _domain_match(hostname, pattern, address_resolution):
 
 
 def _resolve_address(hostname, memo):
-    if memo:
+    """ Perform a DNS resolution on a hostname.
+    If successful, return a tuple containing the resolved hostname,
+    the list of aliases if any, and the list of IP addresses.
+    If unsuccessful, return a tuple containing the value False.
+    Note that if this tuple is evaluated as a boolean, the result is False.
+
+    If 'memo' is present (including if it is a tuple containing only False),
+    then just return 'memo'.
+    """
+    if memo or memo == (False):
         return memo
     try:
         return (socket.gethostbyname_ex(hostname))
     except socket.gaierror:
-        return ()
+        return (False)
 
 
 def _is_subdomain(hostname, pattern):
+    """ Checks whether 'hostname' is equal to 'pattern'
+    or is a subdomain of 'pattern'.
+    """
     return hostname == pattern or hostname.endswith('.' + pattern)
 
 

--- a/ckanext/qgov/common/test_url_validation.py
+++ b/ckanext/qgov/common/test_url_validation.py
@@ -39,6 +39,7 @@ VALID_RESOURCE_URLS = [
     {'whitelist': 'gov.au translink.com.au', 'url_cases': [{'input': 'http://www.translink.com.au'}, {'input': 'https://www.qld.gov.au'}, {'input': 'www.qld.gov.au', 'expected': 'http://www.qld.gov.au'}]},
     # Domain does not match blacklist
     {'blacklist': 'evil.com', 'url_cases': [{'input': 'https://example.com'}, {'input': 'http://evil.com.au'}]},
+    {'blacklist': '1.2.3.4', 'url_cases': [{'input': 'https://example.com.1.2.3.4'}]},
     {'blacklist': 'private', 'url_cases': [
         {'input': 'http://www.qld.gov.au'},
         {'input': 'http://example.com'},


### PR DESCRIPTION
- Don't do subdomain matching on IP addresses
- Check resolved DNS aliases, if any
- Memoize address resolution so we don't repeat it for each whitelist/blacklist entry