### PR TITLE
[QOL-8979] update sysadmin config help text to match field customisations

### DIFF
--- a/ckanext/qgov/common/templates/admin/config.html
+++ b/ckanext/qgov/common/templates/admin/config.html
@@ -22,3 +22,23 @@
 {{ form.textarea('ckanext.data_qld.excluded_display_name_words', id='field-ckanext.data_qld.excluded_display_name_words', label=_('Excluded display name words'), placeholder=_('eg.\nAdmin\nEditor'), value=data['ckanext.data_qld.excluded_display_name_words'], error=errors['ckanext.data_qld.excluded_display_name_words']) }}
 
 {% endblock %}
+
+{% block admin_form_help %}
+{% set about_url = h.url_for(controller='home', action='about') %}
+{% set home_url = h.url_for(controller='home', action='index') %}
+{% set docs_url = "http://docs.ckan.org/en/{0}/theming".format(g.ckan_doc_version) %}
+{% trans %}
+<p><strong>Site Title:</strong> This is the title of this CKAN instance
+    It appears in various places throughout CKAN.</p>
+<p><strong>Site Tag Logo:</strong> This is the logo that appears in the
+    header of all the CKAN instance templates.</p>
+<p><strong>About:</strong> This text will appear on this CKAN instances
+    <a href="{{ about_url }}">about page</a>.</p>
+<p><strong>Intro Text:</strong> This text will appear on this CKAN instances
+    <a href="{{ home_url }}">home page</a> as a welcome to visitors.</p>
+<p><strong>Homepage:</strong> This is for choosing a predefined layout for
+    the modules that appear on your homepage.</p>
+<p><strong>Excluded display name words:</strong> Keywords that are restricted
+    from being included in displayed account names.</p>
+{% endtrans %}
+{% endblock %}

--- a/test/features/config.feature
+++ b/test/features/config.feature
@@ -5,6 +5,7 @@ Feature: Config
         Given "SysAdmin" as the persona
         When I log in and go to admin config page
         Then I should see "Intro Text"
+        And I should see "Excluded display name words:"
         And I should see an element with id "field-ckanext.data_qld.excluded_display_name_words"
         And I should not see an element with id "field-ckan-main-css"
         And I should not see an element with id "field-ckan-site-custom-css"

--- a/test/features/homepage.feature
+++ b/test/features/homepage.feature
@@ -6,4 +6,3 @@ Feature: Homepage
     Scenario: Smoke test to ensure Homepage is accessible
         Given "Unauthenticated" as the persona
         When I go to homepage
-        Then I take a screenshot


### PR DESCRIPTION
- Drop CSS styling
- Add 'Excluded display name words'