### PR TITLE
[QOLDEV-1884] declare namespace via pkg_resources for backwards compatibility

### DIFF
--- a/.ahoy.yml
+++ b/.ahoy.yml
@@ -176,12 +176,12 @@ commands:
         if [ "$CKAN_TYPE" != "custom" ]; then
           BEHAVE_TAG="--tags=-custom"
         fi
-        (ahoy cli "behave $JUNIT_OUTPUT -k ${*:-test/features} --tags=smoke" \
-         && ahoy cli "behave $JUNIT_OUTPUT -k ${*:-test/features} $BEHAVE_TAG --tags=-smoke"
+        (ahoy cli "behave $JUNIT_OUTPUT --no-skipped ${*:-test/features} --tags=smoke" \
+         && ahoy cli "behave $JUNIT_OUTPUT --no-skipped ${*:-test/features} $BEHAVE_TAG --tags=-smoke"
         ) || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       else
         # run tests with the specified tag
-        ahoy cli "behave $JUNIT_OUTPUT -k ${*:-test/features} --tags=$BEHAVE_TAG" \
+        ahoy cli "behave $JUNIT_OUTPUT --no-skipped ${*:-test/features} --tags=$BEHAVE_TAG" \
           || [ "${ALLOW_BDD_FAIL:-0}" -eq 1 ]
       fi
       ahoy stop-mailmock

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -90,7 +90,7 @@ jobs:
         continue-on-error: ${{ matrix.experimental }}
 
       - name: Test Summary
-        uses: test-summary/action@v2
+        uses: test-summary/action@v2.4
         continue-on-error: ${{ matrix.experimental }}
         with:
           paths: "/tmp/artifacts/junit/*.xml"

--- a/ckanext/qgov/__init__.py
+++ b/ckanext/qgov/__init__.py
@@ -1,0 +1,11 @@
+# encoding: utf-8
+
+# Configure namespace via pkg_resources for backwards compatibility.
+# A namespace declaration in a submodule of 'ckanext' is needed for unclear reasons
+# in order for plugins relying on pkg_resources to be imported correctly.
+try:
+    import pkg_resources
+    pkg_resources.declare_namespace(__name__)
+except ImportError:
+    import pkgutil
+    __path__ = pkgutil.extend_path(__path__, __name__)


### PR DESCRIPTION
If we don't have a plugin declaring a namespace in a submodule of 'ckanext', then importing the S3 Filestore plugin fails for reasons not yet clear.